### PR TITLE
Replace std q with a lock free MPMC queue to improve memory performance

### DIFF
--- a/4-EvSchedMPMCExPool/CMakeLists.txt
+++ b/4-EvSchedMPMCExPool/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required(VERSION 3.20)
+project(event_scheduler)
+
+# Set C++20 standard
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Force using Clang
+set(CMAKE_C_COMPILER "/usr/bin/clang")
+set(CMAKE_CXX_COMPILER "/usr/bin/clang++")
+
+# Add coroutines flag for Clang on macOS
+add_compile_options(-std=c++20 -stdlib=libc++ -fcoroutines)
+
+# Add executable
+add_executable(event_scheduler src/main.cpp)
+
+# Include directories
+# target_include_directories(event_scheduler PRIVATE include)
+target_include_directories(event_scheduler PRIVATE 
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+)

--- a/4-EvSchedMPMCExPool/README.md
+++ b/4-EvSchedMPMCExPool/README.md
@@ -1,0 +1,1 @@
+Add memory optimization to the framework in Chapter 3 by implementing a lock-free Multi Producer Multi Consumner (MPMC) queue to hold tasks for the thread pool.

--- a/4-EvSchedMPMCExPool/include/event_scheduler.hpp
+++ b/4-EvSchedMPMCExPool/include/event_scheduler.hpp
@@ -1,0 +1,171 @@
+#pragma once
+#include <unordered_map>
+#include <queue>
+#include <vector>
+#include <memory>
+#include <any>
+#include <string>
+#include <string_view>
+#include <coroutine>
+#include <stdexcept>
+#include <iostream>
+#include "executor.hpp"
+
+class EventScheduler {
+public:
+
+    struct Task {
+        struct promise_type {
+            Task get_return_object() {
+                return Task(std::coroutine_handle<promise_type>::from_promise(*this));
+            }
+            std::suspend_never initial_suspend() noexcept { return {}; }
+            std::suspend_always final_suspend() noexcept { return {}; }
+            void return_void() noexcept {}
+            void unhandled_exception() { std::terminate(); }
+        };
+
+        Task(std::coroutine_handle<promise_type> handle) : _handle(handle) {}
+        Task(const Task&) = delete; 
+        Task& operator=(const Task&) = delete;  
+        Task(Task&& other) noexcept : _handle(other._handle) {  
+            other._handle = nullptr;
+        }
+        ~Task() {
+            if (_handle) _handle.destroy();
+        }
+    private:
+        std::coroutine_handle<promise_type> _handle;
+    };
+
+    template<typename T>
+    struct EventAwaiter {
+        EventAwaiter(EventScheduler& scheduler, std::string_view eventName)
+            : _scheduler(scheduler), _eventName(eventName) {}
+
+        bool await_ready() const noexcept { return false; }
+        
+        void await_suspend(std::coroutine_handle<> handle) {
+            _scheduler.registerHandler(_eventName, handle);
+        }
+
+        T await_resume() {
+            return _scheduler.getEventData<T>(_eventName);
+        }
+
+    private:
+        EventScheduler& _scheduler;
+        std::string_view _eventName;
+    };
+
+    //Add executor-aware awaiter
+    struct ExecutorAwaiter {
+       
+        ExecutorAwaiter(Executor& executor) : _executor(executor) {}
+
+        bool await_ready() const noexcept { return false; }
+
+        void await_suspend(std::coroutine_handle<> handle) {
+            _executor.schedule( [handle] () { handle.resume();});
+        }
+        
+        void await_resume() {}
+        
+    private:
+      Executor& _executor;
+
+    };
+
+    Executor& getExecutor() { return _executor; }
+
+    // Add helper to switch executors
+    ExecutorAwaiter switchToExecutor() {
+        return ExecutorAwaiter(_executor);
+    }
+
+    static EventScheduler& getInstance() {
+        static EventScheduler instance;
+        return instance;
+    }
+
+    void registerHandler(std::string_view eventName, std::coroutine_handle<> handle) {
+        std::cout << "Registering handler for: " << eventName << std::endl;
+        auto& handlersVec = _handlersMap[std::string(eventName)];
+
+        // Don't register duplicate handles.
+        if (std::find(begin(handlersVec), end(handlersVec), handle) != end(handlersVec)) return;
+        
+        handlersVec.emplace_back(handle);
+    }
+
+    template<typename T>
+    void emit(std::string_view eventName, T data) {
+        _eventsQ.push(std::make_unique<TypedEvent<T>>(eventName, std::move(data)));
+        processEvents();
+    }
+
+private:
+
+    struct Event {
+        Event(std::string_view name) : eventName(name) {}
+        virtual ~Event() = default;
+        virtual void storeData(std::unordered_map<std::string, std::any>& eventData) = 0;
+        std::string eventName;
+    };
+
+    template<typename T>
+    struct TypedEvent : Event {
+        TypedEvent(std::string_view name, T value) 
+            : Event(name), data(std::move(value)) {}
+        void storeData(std::unordered_map<std::string, std::any>& eventData) override {
+            eventData[eventName] = data;
+        }
+        T data;
+     };
+
+    template<typename T>
+    T getEventData(std::string_view eventName) {
+        if (0 ==  _eventDataMap.count(std::string(eventName))) {
+            throw std::runtime_error("Event data not found");
+        }
+    
+        return std::any_cast<T>(_eventDataMap[std::string(eventName)]);
+    }
+
+    void processEvents() {
+        while (!empty(_eventsQ)) {
+            auto eventPtr = std::move(_eventsQ.front());
+            _eventsQ.pop();
+            
+            eventPtr->storeData(_eventDataMap);
+            auto eventName = eventPtr->eventName;
+            
+            if (_handlersMap.count(eventName) == 0) continue;
+            size_t handlerCount = size(_handlersMap[eventName]);
+            if (handlerCount == 0) {
+                _eventDataMap.erase(eventName);
+                continue;
+            }
+             
+            std::shared_ptr<size_t> completedCount = std::make_shared<size_t>(0);
+             
+            for (auto& handle : _handlersMap[eventName]) {
+                _executor.schedule([this, handle, eventName, handlerCount, completedCount]() {
+                    handle.resume();
+                    // Increment completed count and check if all handlers are done
+                    if (++(*completedCount) == handlerCount) { _eventDataMap.erase(eventName);}
+                });
+            }
+        }
+    }
+
+    Executor _executor;
+    std::unordered_map<std::string, std::vector<std::coroutine_handle<>>> _handlersMap;
+    std::queue<std::unique_ptr<Event>> _eventsQ;
+    std::unordered_map<std::string, std::any> _eventDataMap;
+};
+
+template<typename T>
+auto awaitEvent(std::string_view eventName) {
+    return EventScheduler::EventAwaiter<T>(EventScheduler::getInstance(), eventName);
+}

--- a/4-EvSchedMPMCExPool/include/executor.hpp
+++ b/4-EvSchedMPMCExPool/include/executor.hpp
@@ -1,0 +1,80 @@
+#pragma once
+#include <queue>
+#include <functional>
+#include <thread>
+#include <mutex>
+#include <condition_variable>
+#include <vector>
+#include "mpmc_queue.hpp"
+
+class Executor {
+ public:
+    using Task = std::function<void()>;
+    
+    explicit Executor(size_t thread_count = std::thread::hardware_concurrency()) 
+    : stopped(false) {
+        createThreadPool(thread_count);
+    }
+
+    ~Executor() {
+        if (!stopped) stop();
+    }
+
+    void schedule(Task task) {
+        if (stopped) return;
+        _tasksQ.push(std::move(task));
+        _cv.notify_one();
+    }
+
+    void start() {}
+
+    void stop() {
+        {
+            std::lock_guard<std::mutex> lock(_mutex);
+            stopped = true;
+        }
+        _cv.notify_all();
+
+        for (auto& thread : _threads) {
+            if (thread.joinable()) thread.join();
+        }
+        _threads.clear();
+    }
+
+ private:
+    void createThreadPool(size_t thread_count) {
+        for (size_t i = 0; i < thread_count; ++i) {
+            _threads.emplace_back([this] () { run(); });
+        }
+    }
+    void run () {
+        while (true) {
+            Task task;
+            bool hasTask = false;
+            {
+                std::unique_lock<std::mutex> lock(_mutex);
+                _cv.wait(lock, [this, &task, &hasTask] {
+                    hasTask = _tasksQ.try_pop(task);
+                    return stopped || hasTask;
+                });
+
+                if (stopped) return;
+            }
+            if (hasTask) {
+                try {
+                    task(); //run the task
+                } catch (const std::exception& e) {
+                    std::cerr << "Task exception: " << e.what() << std::endl;
+                } catch (...) {
+                    std::cerr << "Unknown task exception occurred" << std::endl;
+                }
+            }
+        }
+    }
+
+    std::vector<std::thread> _threads;
+    MPMCQueue<Task> _tasksQ;
+    std::mutex _mutex;
+    std::condition_variable _cv;
+    std::atomic<bool> stopped;
+};

--- a/4-EvSchedMPMCExPool/include/mpmc_queue.hpp
+++ b/4-EvSchedMPMCExPool/include/mpmc_queue.hpp
@@ -1,0 +1,79 @@
+#pragma once
+#include <array>
+#include <atomic>
+#include <mutex>
+
+//Lock free MPMC queue for memory optimization
+template <typename T>
+class MPMCQueue {
+private:
+    struct Node {
+        std::atomic<Node*> next{nullptr};
+        T data;
+    };
+
+    std::atomic<Node*> head{nullptr};
+    std::atomic<Node*> tail{nullptr};
+    std::mutex _mutex;
+
+    static constexpr size_t POOL_SIZE = 1024;
+    std::array<Node, POOL_SIZE> node_pool;
+    std::atomic<size_t> pool_idx{0};
+
+    Node* allocateNode() {
+        std::lock_guard<std::mutex> lock(_mutex);
+        auto idx = pool_idx.fetch_add(1) % POOL_SIZE;
+        auto node = &node_pool[idx];
+        node->next.store(nullptr);
+        return node;
+    }
+
+public:
+    MPMCQueue() {
+        auto dummy = allocateNode();
+        head.store(dummy);
+        tail.store(dummy);
+    }
+
+    void push(T value) {
+        auto node = allocateNode();
+        node->data = std::move(value);
+
+        while(true) {
+            auto old_tail = tail.load(std::memory_order_acquire);
+            auto next = old_tail->next.load(std::memory_order_acquire);
+
+            if (old_tail == tail.load(std::memory_order_acquire)) {
+                if (next == nullptr) {
+                    if (old_tail->next.compare_exchange_weak(next, node,
+                        std::memory_order_release, std::memory_order_acquire)) {
+                        tail.compare_exchange_strong(old_tail, node,
+                            std::memory_order_release, std::memory_order_relaxed);
+                        return;
+                    }
+                } else {
+                    tail.compare_exchange_strong(old_tail, next,
+                        std::memory_order_release, std::memory_order_acquire);
+                }
+            }
+        }
+    }
+
+    bool try_pop(T& value) {
+        while (true) {
+            auto old_head = head.load(std::memory_order_acquire);
+            if (!old_head) return false;
+            
+            auto next = old_head->next.load(std::memory_order_acquire);
+            if (!next) return false;
+
+            if (old_head == head.load(std::memory_order_acquire)) {
+                if (head.compare_exchange_weak(old_head, next,
+                    std::memory_order_release, std::memory_order_acquire)) {
+                    value = std::move(next->data);
+                    return true;
+                }
+            }
+        }
+    }
+}; 

--- a/4-EvSchedMPMCExPool/src/main.cpp
+++ b/4-EvSchedMPMCExPool/src/main.cpp
@@ -1,0 +1,101 @@
+#include "event_scheduler.hpp"
+#include <iostream>
+#include <string>
+#include <chrono>
+
+// Event type definitions
+enum class EventType {
+    UserLogin,
+    NewMessage,
+    SystemStatus
+};
+
+// Event handlers class to contain all event handling logic
+class EventHandlers {
+public:
+    static EventScheduler::Task handleLoginEvent() {
+        co_await EventScheduler::getInstance().switchToExecutor();
+        auto userData = co_await awaitEvent<std::string>(toString(EventType::UserLogin));
+        std::cout << "User logged in: " << userData << std::endl;
+        
+        while (true) {
+            co_await std::suspend_always{};
+        }
+    }
+
+    static EventScheduler::Task handleMessageEvent() {
+        co_await EventScheduler::getInstance().switchToExecutor();
+        auto message = co_await awaitEvent<std::string>(toString(EventType::NewMessage));
+        std::cout << "New message received: " << message << std::endl;
+        
+        while (true) {
+            co_await std::suspend_always{};
+        }
+    }
+
+    static EventScheduler::Task handleSystemStatusEvent() {
+        co_await EventScheduler::getInstance().switchToExecutor();
+        auto status = co_await awaitEvent<int>(toString(EventType::SystemStatus));
+        std::cout << "System status changed: " << status << std::endl;
+        
+        while (true) {
+            co_await std::suspend_always{};
+        }
+    }
+
+    static std::string_view toString(EventType type) {
+        switch (type) {
+            case EventType::UserLogin: return "user_login";
+            case EventType::NewMessage: return "new_message";
+            case EventType::SystemStatus: return "system_status";
+        }
+        throw std::runtime_error("Unknown event type");
+    }
+};
+
+// Event registry to manage handler registration
+class EventRegistry {
+public:
+    static EventRegistry& getInstance() {
+        static EventRegistry instance;
+        return instance;
+    }
+
+    void registerAllHandlers() {
+        tasks.push_back(EventHandlers::handleLoginEvent());
+        tasks.push_back(EventHandlers::handleMessageEvent());
+        tasks.push_back(EventHandlers::handleSystemStatusEvent());
+    }
+
+private:
+    std::vector<EventScheduler::Task> tasks;
+};
+
+int main() {
+    auto& scheduler = EventScheduler::getInstance();
+    
+    std::cout << "Starting executor..." << std::endl;
+    scheduler.getExecutor().start();
+
+    std::cout << "Registering handlers..." << std::endl;
+    EventRegistry::getInstance().registerAllHandlers();
+
+    // Give time for handlers to register
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::cout << "Emitting user_login event..." << std::endl;
+    scheduler.emit(EventHandlers::toString(EventType::UserLogin), std::string("john_doe"));
+    
+    std::cout << "Emitting new_message event..." << std::endl;
+    scheduler.emit(EventHandlers::toString(EventType::NewMessage), std::string("Hello, World!"));
+    
+    std::cout << "Emitting system_status event..." << std::endl;
+    scheduler.emit(EventHandlers::toString(EventType::SystemStatus), 1);
+
+    // Wait for events to process
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    std::cout << "Stopping executor..." << std::endl;
+    scheduler.getExecutor().stop();
+    return 0;
+}


### PR DESCRIPTION
* Replace the standard queue for registering tasks with a lock free implementation of multiple-producer multiple consumer queue to improve memory optimization of the event framework.